### PR TITLE
De-emphasize racing in copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <header>
       <h1>Andrew Coomes</h1>
       <p class="lede">Product and software. Portland.</p>
-      <p>Former Formula Drift driver. Builds products and the tools around them.</p>
+      <p>Builds products and the tools around them.</p>
     </header>
 
     <section>
@@ -49,7 +49,7 @@
 
     <section>
       <h2>About</h2>
-      <p>Andrew lives in Portland. He drove in Formula Drift (professional license, 2012), then moved into software at Catalyte and into product at Nike, Columbia, Phoenix, and D8TAOPS. Certified Scrum Master and Certified Scrum Product Owner.</p>
+      <p>Andrew lives in Portland. He's worked in product and software at D8TAOPS, Phoenix (FirmGuard), Columbia, Nike, and Catalyte. He held a Formula Drift license in 2012. Certified Scrum Master and Certified Scrum Product Owner.</p>
     </section>
 
     <section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes Formula Drift / racing from headline and intro, and repositions it as a small factual detail in the About section.

## Changes

**Intro header** (line 17)
- Before: "Former Formula Drift driver. Builds products and the tools around them."
- After: "Builds products and the tools around them."

**About section** (line 52)
- Before: "Andrew lives in Portland. He drove in Formula Drift (professional license, 2012), then moved into software at Catalyte and into product at Nike, Columbia, Phoenix, and D8TAOPS."
- After: "Andrew lives in Portland. He's worked in product and software at D8TAOPS, Phoenix (FirmGuard), Columbia, Nike, and Catalyte. He held a Formula Drift license in 2012."

## Outcome
- First-time visitors see product/software as the primary identity
- Racing is still mentioned but does not lead the page or the career narrative
- Voice remains quiet and sharp
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e60f8fc7-801b-448b-9473-2c3508c64cb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e60f8fc7-801b-448b-9473-2c3508c64cb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

