### PR TITLE
Move theme switcher from header to bottom of page

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,13 +41,6 @@
       <h1>Andrew Coomes</h1>
       <p class="lede">Product and software. Portland.</p>
       <p>Builds products and the tools around them.</p>
-      <div class="theme-switcher" role="radiogroup" aria-label="Theme selection">
-        <button type="button" role="radio" aria-checked="false" data-theme="light">Light</button>
-        <span aria-hidden="true">/</span>
-        <button type="button" role="radio" aria-checked="false" data-theme="dark">Dark</button>
-        <span aria-hidden="true">/</span>
-        <button type="button" role="radio" aria-checked="true" data-theme="system">System</button>
-      </div>
     </header>
 
     <section>
@@ -93,6 +86,14 @@
         <li>GitHub: <a href="https://github.com/acoomes">acoomes</a></li>
       </ul>
     </section>
+
+    <div class="theme-switcher" role="radiogroup" aria-label="Theme selection">
+      <button type="button" role="radio" aria-checked="false" data-theme="light">Light</button>
+      <span aria-hidden="true">/</span>
+      <button type="button" role="radio" aria-checked="false" data-theme="dark">Dark</button>
+      <span aria-hidden="true">/</span>
+      <button type="button" role="radio" aria-checked="true" data-theme="system">System</button>
+    </div>
   </main>
   <script>
     (function() {

--- a/style.css
+++ b/style.css
@@ -157,7 +157,7 @@ a:hover {
 }
 
 .theme-switcher {
-  margin-top: 24px;
+  margin-top: 64px;
   font-size: 14px;
   color: var(--text-light);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The header currently reads as name, lede, one line of copy, then immediately Light / Dark / System. That control is the fourth thing you see. It competes with the intro. The site should be quieter.

## Changes

- Moved `.theme-switcher` markup out of `<header>` to the end of `<main>`, after the Contact section
- Increased top margin from 24px to 64px for better visual separation from the Contact section
- Preserved all existing functionality: three-way Light/Dark/System control, localStorage, no-flash head script, ARIA, and CSS variables

## Result

The first screen is now name + product/software intro. The theme control is still easy to find at the bottom of the page, but doesn't compete with the introduction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaec9c45-3439-4805-9e1d-ce9913fe5ab5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaec9c45-3439-4805-9e1d-ce9913fe5ab5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

