### PR TITLE
Change About section from third person to first person

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
 
     <section>
       <h2>About</h2>
-      <p>Andrew lives in Portland. He's worked in product and software at D8TAOPS, Phoenix (FirmGuard), Columbia, Nike, and Catalyte. He held a Formula Drift license in 2012. Certified Scrum Master and Certified Scrum Product Owner.</p>
+      <p>I live in Portland. I've worked in product and software at D8TAOPS, Phoenix (FirmGuard), Columbia, Nike, and Catalyte. I held a Formula Drift license in 2012. Certified Scrum Master and Certified Scrum Product Owner.</p>
     </section>
 
     <section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the About section to use first person (I/I've) instead of third person (Andrew/He's).

**Changes:**
- "Andrew lives in Portland" → "I live in Portland"
- "He's worked" → "I've worked"
- "He held" → "I held"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab9383d4-690b-492d-bfd2-1c7adc417a63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab9383d4-690b-492d-bfd2-1c7adc417a63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

